### PR TITLE
Make no_std, remove unsafe code for core types

### DIFF
--- a/src/enumerable.rs
+++ b/src/enumerable.rs
@@ -26,19 +26,12 @@ impl<T: Enum> PartialEnum for T {
 
 impl Enum for char {
 	fn pred(&self) -> Option<Self> {
-		match self {
-			'\u{0000}' => None,
-			'\u{e000}' => Some('\u{d7ff}'),
-			_ => Some(unsafe { std::char::from_u32_unchecked(*self as u32 - 1) }),
-		}
+		('\u{0000}'..*self).next_back()
 	}
 
 	fn succ(&self) -> Option<Self> {
-		match self {
-			'\u{10ffff}' => None,
-			'\u{d7ff}' => Some('\u{e000}'),
-			_ => Some(unsafe { std::char::from_u32_unchecked(*self as u32 + 1) }),
-		}
+		// we skip one element since that's the current char, not its successor
+		(*self..='\u{10ffff}').nth(1)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 //! that define data-structures indexed by ranges.
 //! By implementing the traits defined in here, one can extend the type of
 //! ranges supported by `btree-range-map`, without necessarily depending on it.
+#![no_std]
 
 mod bounded;
 mod enumerable;

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -5,14 +5,14 @@ use core::{
 
 /// Distance between singletons.
 #[allow(clippy::len_without_is_empty)]
-pub trait Measure<U = Self> {
+pub trait Measure<Rhs: ?Sized = Self> {
 	type Len: Default + Add<Output = Self::Len> + Sub<Output = Self::Len> + PartialEq;
 
 	/// Returns the length of the given element.
 	fn len(&self) -> Self::Len;
 
 	/// Returns the distance to the given other element.
-	fn distance(&self, other: &U) -> Self::Len;
+	fn distance(&self, other: &Rhs) -> Self::Len;
 }
 
 impl Measure for char {

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -1,10 +1,12 @@
+use core::{
+	mem,
+	ops::{Add, Sub},
+};
+
 /// Distance between singletons.
 #[allow(clippy::len_without_is_empty)]
 pub trait Measure<U = Self> {
-	type Len: Default
-		+ std::ops::Add<Output = Self::Len>
-		+ std::ops::Sub<Output = Self::Len>
-		+ PartialEq;
+	type Len: Default + Add<Output = Self::Len> + Sub<Output = Self::Len> + PartialEq;
 
 	/// Returns the length of the given element.
 	fn len(&self) -> Self::Len;
@@ -25,7 +27,7 @@ impl Measure for char {
 		let mut b = *other as u64;
 
 		if a > b {
-			std::mem::swap(&mut a, &mut b);
+			mem::swap(&mut a, &mut b);
 		}
 
 		if (..=0xd7ff).contains(&a) && (0xe000..).contains(&b) {


### PR DESCRIPTION
Separated into three commits:

1.<del> `cargo fmt` missed the hard tabstops in macros, making the crate use both four spaces and tabs. This replaces the tabs for consistency.</del> Replaced by new upstream commit which uses tabs everywhere.
2. The implementations of `pred` and `succ` use a hand-rolled implementation with unsafe code; we can leverage the already existing implementation in libstd by using ranges.
3. Replacing the remaining `std` paths with `core` lets us just mark the entire crate as `no_std`
4. To better reflect other operator traits, `Measure<U>` is now `Measure<Rhs>`. Also, `Rhs: ?Sized` for symmetry.