### PR TITLE
Add measure for nonzero types

### DIFF
--- a/src/bounded.rs
+++ b/src/bounded.rs
@@ -1,3 +1,8 @@
+use core::num::{
+	NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+	NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+};
+
 pub trait MaybeBounded: Sized {
 	fn min() -> Option<Self>;
 	fn max() -> Option<Self>;
@@ -44,7 +49,32 @@ macro_rules! impl_int {
 	};
 }
 
-impl_int!(u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize);
+impl_int!(
+	u8,
+	u16,
+	u32,
+	u64,
+	u128,
+	usize,
+	i8,
+	i16,
+	i32,
+	i64,
+	i128,
+	isize,
+	NonZeroU8,
+	NonZeroU16,
+	NonZeroU32,
+	NonZeroU64,
+	NonZeroU128,
+	NonZeroUsize,
+	NonZeroI8,
+	NonZeroI16,
+	NonZeroI32,
+	NonZeroI64,
+	NonZeroI128,
+	NonZeroIsize
+);
 
 macro_rules! impl_float {
 	($($ty:ident),*) => {

--- a/src/enumerable.rs
+++ b/src/enumerable.rs
@@ -70,3 +70,30 @@ macro_rules! impl_float {
 }
 
 impl_float!(f32, f64);
+
+macro_rules! impl_nonzero {
+	($($ty:ident),*) => {
+		$(
+			impl PartialEnum for $ty {
+				fn pred(&self) -> Option<Self> {
+					self.get().checked_sub(1).and_then($ty::new)
+				}
+
+				fn succ(&self) -> Option<Self> {
+					self.checked_add(1)
+				}
+			}
+		)*
+	};
+}
+
+use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
+
+impl_nonzero!(
+	NonZeroU8,
+	NonZeroU16,
+	NonZeroU32,
+	NonZeroU64,
+	NonZeroU128,
+	NonZeroUsize
+);

--- a/src/enumerable.rs
+++ b/src/enumerable.rs
@@ -89,6 +89,7 @@ macro_rules! impl_nonzero {
 
 use core::num::{NonZeroU128, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize};
 
+// Only implement for unsigned non-zero types, since enumerating signed non-zero types is not well-defined
 impl_nonzero!(
 	NonZeroU8,
 	NonZeroU16,

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -1,5 +1,6 @@
 use core::{
 	mem,
+	num::NonZero,
 	ops::{Add, Sub},
 };
 
@@ -232,3 +233,28 @@ mod ordered_float {
 		unsafe { NotNan::new_unchecked(f64::INFINITY) }
 	);
 }
+
+macro_rules! impl_nonzero_measure {
+	($ty:ty) => {
+		impl Measure for NonZero<$ty> {
+			type Len = <$ty as Measure>::Len;
+
+			fn len(&self) -> Self::Len {
+				<$ty as Measure>::len(&self.get())
+			}
+
+			fn distance(&self, other: &Self) -> Self::Len {
+				<$ty as Measure>::distance(&self.get(), &other.get())
+			}
+		}
+	};
+}
+
+impl_nonzero_measure!(u8);
+impl_nonzero_measure!(u16);
+impl_nonzero_measure!(u32);
+impl_nonzero_measure!(u64);
+impl_nonzero_measure!(i8);
+impl_nonzero_measure!(i16);
+impl_nonzero_measure!(i32);
+impl_nonzero_measure!(i64);

--- a/src/measure.rs
+++ b/src/measure.rs
@@ -236,7 +236,7 @@ mod ordered_float {
 
 macro_rules! impl_nonzero_measure {
 	($ty:ty) => {
-		impl Measure for NonZero<$ty> {
+		impl Measure<NonZero<$ty>> for NonZero<$ty> {
 			type Len = <$ty as Measure>::Len;
 
 			fn len(&self) -> Self::Len {
@@ -254,7 +254,4 @@ impl_nonzero_measure!(u8);
 impl_nonzero_measure!(u16);
 impl_nonzero_measure!(u32);
 impl_nonzero_measure!(u64);
-impl_nonzero_measure!(i8);
-impl_nonzero_measure!(i16);
-impl_nonzero_measure!(i32);
-impl_nonzero_measure!(i64);
+impl_nonzero_measure!(usize);


### PR DESCRIPTION
Hi, 

We are trying to use RangeSet [here](https://github.com/ava-labs/firewood/blob/qusuyan/fsck/storage/src/range_set.rs#L12) to ensure that we do not have any disk space leaks. 

Our disk address is `NonZeroU64` typed and we currently have to convert it to `u64`. It would be great if it can natively support `NonZero` types. 